### PR TITLE
Reduce docker images size 

### DIFF
--- a/cmd/tracer-node/Dockerfile
+++ b/cmd/tracer-node/Dockerfile
@@ -1,47 +1,66 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright 2022 VMware Inc, June Knauth (VMware) <june.knauth@gmail.com>
+# Copyright 2023 VMware, Inc. Tzvetomir Stoyanov (VMware) <tz.stoyanov@gmail.com>
 
-FROM golang:1.18-bullseye
-# Install APT and pip dependencies
+FROM golang:1.18-bullseye as build
+
 RUN apt update \
 	&& apt install build-essential git cmake \
 		libjson-c-dev libpython3-dev cython3 \
 		python3-numpy python3-pip flex valgrind \
 		binutils-dev libzstd-dev libaudit-dev pkg-config \
 		swig curl -y \
-&& pip3 install pkgconfig GitPython
-# Download the git-snapshot tool from the trace-cruncher GitHub and
-# use it to download a snapshot of trace-cruncher dependencies (defined in repos)
-ARG TRACE_CRUNCER_URL=https://github.com/vmware/trace-cruncher
-ARG TRACE_CRUNCER_VER=tracecruncher
-WORKDIR /build
-RUN git clone ${TRACE_CRUNCER_URL} --branch ${TRACE_CRUNCER_VER}
-RUN cp ./trace-cruncher/scripts/git-snapshot/* . && bash ./git-snapshot.sh -f ./repos
+	&& pip3 install pkgconfig GitPython 
 
-# Build kernel tracing libs
-RUN cd libtraceevent && make && make install
-RUN cd libtracefs && make && make install
-RUN cd trace-cmd && make && make install_libs
-RUN cd kernel-shark/build && cmake .. && make && make install
-# Install trace-cruncher
-RUN cd trace-cruncher && make && make install
-
-WORKDIR container-tracer
+WORKDIR /tracer
 COPY . ./
 RUN make tracer
 
-WORKDIR /tracer
-COPY trace-hooks trace-hooks
-RUN cp /build/container-tracer/cmd/tracer-node/tracer-node .
+WORKDIR /build
+ARG TRACE_CRUNCER_URL=https://github.com/vmware/trace-cruncher
+ARG TRACE_CRUNCER_VER=tracecruncher
+RUN git clone ${TRACE_CRUNCER_URL} --branch ${TRACE_CRUNCER_VER} \
+	&& cp ./trace-cruncher/scripts/git-snapshot/* . && bash ./git-snapshot.sh -f ./repos 
 
+RUN cd libtraceevent && make && make install \
+	&& cd ../libtracefs && make && make install \
+	&& cd ../trace-cmd && make && make install_libs \
+	&& cd ../kernel-shark/build && cmake .. && make && make install \
+	&& cd ../../trace-cruncher && make
+
+####
+
+FROM debian:stable-slim
+
+# Install APT and pip dependencies
+RUN apt update \
+	&& apt install make cmake \
+		libjson-c-dev cython3 libzstd-dev \
+		python3-numpy python3-pip \
+		pkg-config -y \
+	&& pip3 install pkgconfig GitPython
+
+WORKDIR /build
+COPY --from=build /build .
+
+RUN cd libtraceevent && make -t && make install \
+	&& cd ../libtracefs && make -t && make install \
+	&& cd ../trace-cmd && make -t && make install_libs \
+	&& cd ../kernel-shark/build && make -t && make install \
+	&& cd ../../trace-cruncher && make -t && make install
+
+WORKDIR /tracer
 # Remove build dependencies; run build with --squash to reduce image size
-RUN rm -rf /build /root/go /go /usr/local/go /root/.cache/*
 RUN pip3 uninstall pkgconfig -y \
-	&& apt remove build-essential git cmake python3-pip libpython3-dev flex valgrind \
-		binutils-dev libzstd-dev libaudit-dev pkg-config swig curl -y \
-	&& apt autoremove -y
-EXPOSE 8080/tcp
-WORKDIR /tracer
-ENTRYPOINT ["./tracer-node"]
+	&& apt remove make cmake libzstd-dev \
+		pkg-config -y \
+	&& apt remove python3-pip -y \
+	&& apt autoremove -y \
+	&& rm -rf /build /root/.cache/*
 
+COPY --from=build /tracer/cmd/tracer-node/tracer-node .
+COPY --from=build /tracer/trace-hooks .
+
+EXPOSE 8080/tcp
+ENTRYPOINT ["./tracer-node"]

--- a/cmd/tracer-svc/Dockerfile
+++ b/cmd/tracer-svc/Dockerfile
@@ -2,18 +2,15 @@
 #
 # Copyright (C) 2022 VMware, Inc. Tzvetomir Stoyanov (VMware) <tz.stoyanov@gmail.com>
 
-FROM golang:1.18-bullseye
+FROM golang:1.18-bullseye as build
 
 WORKDIR /build/container-tracer
 COPY . ./
 RUN make service
 
-WORKDIR /tracer
-RUN cp /build/container-tracer/cmd/tracer-svc/tracer-svc .
+RUN cp /build/container-tracer/cmd/tracer-svc/tracer-svc /
 
-# Remove build dependencies; run build with --squash to reduce image size
-RUN rm -rf /build /root/go /go /usr/local/go /root/.cache/*
-RUN apt autoremove -y
+FROM gcr.io/distroless/static-debian11
+COPY --from=build /tracer-svc /
 EXPOSE 8080/tcp
-WORKDIR /tracer
-ENTRYPOINT ["./tracer-svc"]
+ENTRYPOINT ["/tracer-svc"]


### PR DESCRIPTION
Introduced multi-stage build of the docker images, to reduce their size. The size of `tracer-svc` is reduced to 47.5MB, which is optimal. The size of `tracer-node` is reduced to 666MB - still huge and can be optimized further. 