### PR TITLE
Fix trace-hook location

### DIFF
--- a/cmd/tracer-node/Dockerfile
+++ b/cmd/tracer-node/Dockerfile
@@ -60,7 +60,7 @@ RUN pip3 uninstall pkgconfig -y \
 	&& rm -rf /build /root/.cache/*
 
 COPY --from=build /tracer/cmd/tracer-node/tracer-node .
-COPY --from=build /tracer/trace-hooks .
+COPY --from=build /tracer/trace-hooks ./trace-hooks
 
 EXPOSE 8080/tcp
 ENTRYPOINT ["./tracer-node"]


### PR DESCRIPTION
When the docker image is build, the trace-hook directory must be at the same location as the tracer-scv application. With recent images optimization, this was broken. Fix the location and the name of the directory with the trace-hooks in the docker image.