### PR TITLE
Update to the latest trace-cruncher release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ GO = CGO_ENABLED=0 GOOS=linux go
 BIN_TRACER=tracer-node
 BIN_SVC=tracer-svc
 TRACE_CRUNCER_URL=https://github.com/vmware/trace-cruncher
-TRACE_CRUNCER_VER=tracecruncher-v0.3.0
+TRACE_CRUNCER_VER=tracecruncher-v0.4.0
 
 all: build
 


### PR DESCRIPTION
Use the latest trace-cruncher v0.4.0, the APIs introduced in that version are needed to implement new trace hooks.