### PR TITLE
Disable parent filtering logic

### DIFF
--- a/internal/tracehook/hookdb.go
+++ b/internal/tracehook/hookdb.go
@@ -176,12 +176,14 @@ func (h *TraceHooks) Run(th *TraceHook, pids *[]int, parent *[]int, params *[]st
 		sargs += " " + strconv.Itoa(p)
 	}
 
+	/* temporary disable parent filtering, due to an issue with trace instance deletion
 	if parent != nil {
 		sargs += " --parent"
 		for _, p := range *parent {
 			sargs += " " + strconv.Itoa(p)
 		}
 	}
+	*/
 
 	for _, p := range *params {
 		sargs += " " + p


### PR DESCRIPTION
There is an timeout problem with trace session deletion, when a filter for parents processes is applied on the events tracing. Temporary disable that logic, until the problem is analyzed and fixed.